### PR TITLE
Fix two small bugs with sparse factorization.

### DIFF
--- a/kpoint_eri/resource_estimates/sparse/compute_lambda_sparse.py
+++ b/kpoint_eri/resource_estimates/sparse/compute_lambda_sparse.py
@@ -105,7 +105,7 @@ def compute_lambda_ncr(hcore, sparse_int_obj):
             for qidx in range(nkpts):                 
                 kmq_idx = sparse_int_obj.k_transfer_map[qidx, kidx]
                 kpmq_idx = sparse_int_obj.k_transfer_map[qidx, kpidx]
-                test_eri_block = sparse_int_obj.get_eri([kidx, kmq_idx, kpmq_idx, kpidx])
+                test_eri_block = sparse_int_obj.get_eri([kidx, kmq_idx, kpmq_idx, kpidx]) / nkpts
                 lambda_two_body += np.sum(np.abs(test_eri_block.real)) + np.sum(np.abs(test_eri_block.imag))
 
     lambda_tot = lambda_one_body + lambda_two_body

--- a/kpoint_eri/resource_estimates/sparse/ncr_sparse_integral_helper.py
+++ b/kpoint_eri/resource_estimates/sparse/ncr_sparse_integral_helper.py
@@ -140,6 +140,6 @@ class NCRSSparseFactorizationHelper:
             assert np.allclose(np.einsum('npq,nsr->pqrs', self.chol[ikp, ikq], self.chol[iks, ikr].conj(), optimize=True),
                                np.einsum('npq,nrs->pqrs', self.chol[ikp, ikq], self.chol[ikr, iks], optimize=True))
         kpoint_eri_tensor = np.einsum('npq,nsr->pqrs', self.chol[ikp, ikq], self.chol[iks, ikr].conj(), optimize=True)
-        zero_mask = kpoint_eri_tensor < self.threshold
+        zero_mask = np.abs(kpoint_eri_tensor) < self.threshold
         kpoint_eri_tensor[zero_mask] = 0
         return kpoint_eri_tensor


### PR DESCRIPTION
Missing factor of Nk in lambda and need to use abs for screening integrals. Note this causes unit test to fail, but I believe the existing unit test [test](https://github.com/ncrubin/kpoint_eri/blob/main/kpoint_eri/resource_estimates/sparse/compute_lambda_sparse_test.py#L63) is comparing the unit cell lambda to itself (rather than passing supercell_helper to compute_lambda_ncr)