### PR TITLE
Trigger test for sparse lambda.

### DIFF
--- a/kpoint_eri/resource_estimates/sparse/compute_lambda_sparse_test.py
+++ b/kpoint_eri/resource_estimates/sparse/compute_lambda_sparse_test.py
@@ -1,6 +1,8 @@
 from functools import reduce
 import numpy as np
-from pyscf.pbc import gto, scf, mp, cc
+import h5py
+from pyscf.pbc import gto, scf, mp, cc, tools
+from pyscf.pbc.lib.kpts_helper import loop_kkk, get_kconserv
 
 from kpoint_eri.resource_estimates import sparse
 from kpoint_eri.resource_estimates import utils
@@ -13,6 +15,7 @@ def test_lambda_sparse():
     cell, kmf = utils.init_from_chkfile('diamond_221.chk')
     lambda_tot, lambda_T, lambda_V  = sparse.compute_lambda(kmf)
     print(lambda_tot)
+
 
 def test_ncr_lambda_sparse():
     cell = gto.Cell()
@@ -27,7 +30,7 @@ def test_ncr_lambda_sparse():
     3.370137329, 0.000000000, 3.370137329
     3.370137329, 3.370137329, 0.000000000'''
     cell.unit = 'B'
-    cell.verbose = 0
+    cell.verbose = 3
     cell.build()
 
     kmesh = [1, 1, 3]
@@ -47,22 +50,59 @@ def test_ncr_lambda_sparse():
 
     lambda_tot, lambda_one_body, lambda_two_body = compute_lambda_ncr(hcore_mo, helper)
 
-    from pyscf.pbc.tools.k2gamma import k2gamma
-    from kpoint_eri.resource_estimates.utils.k2gamma import k2gamma
-    supercell_mf = k2gamma(mf)
-    supercell_mf.kernel()
-    assert np.isclose(mf.e_tot, supercell_mf.e_tot / np.prod(kmesh))
+    from kpoint_eri.resource_estimates.utils.k2gamma import k2gamma, get_phase
+    supercell_mf = k2gamma(mf, make_real=False)
+    dm0 = supercell_mf.make_rdm1()
+    # supercell_mf.kernel(dm0)
+    energy_tot_sc = supercell_mf.energy_tot()
+    assert np.isclose(mf.e_tot, energy_tot_sc / np.prod(kmesh))
 
     supercell_mymp = mp.KMP2(supercell_mf)
     supercell_Luv = cholesky_from_df_ints(supercell_mymp)
     supercell_helper = NCRSSparseFactorizationHelper(cholesky_factor=supercell_Luv, kmf=supercell_mf)
 
+    # Sanity check to see that k2gamma supercell AO hcore is same as literal
+    # supercell hcore
+    _, C = get_phase(cell, kpts)
     supercell_hcore_ao = supercell_mf.get_hcore()
+    nkpts = np.prod(kmesh)
+    nmo = mf.mo_coeff[0].shape[-1]
+    kp_sc_hcore_ao = np.einsum("Rk,kij,Sk->RiSj", C, hcore_ao,
+                               C.conj()).reshape((nmo*nkpts, nmo*nkpts))
+    assert np.isclose(np.abs(np.max(supercell_hcore_ao.imag)), 0.0)
+    assert np.isclose(np.abs(np.max(kp_sc_hcore_ao.imag)), 0.0)
+    assert np.allclose(supercell_hcore_ao, kp_sc_hcore_ao)
     supercell_hcore_mo = np.asarray([reduce(np.dot, (mo.T.conj(), supercell_hcore_ao[k], mo)) for k, mo in enumerate(supercell_mf.mo_coeff)])
 
-    sc_lambda_tot, sc_lambda_one_body, sc_lambda_two_body = compute_lambda_ncr(hcore_mo, helper)
+    sc_lambda_tot, sc_lambda_one_body, sc_lambda_two_body = compute_lambda_ncr(supercell_hcore_mo, supercell_helper)
+
+    # Sanity check Tpq by itself without any eri contribution
+    norm_uc_T = sum(np.sum(np.abs(hk.real)+np.abs(hk.imag)) for hk in hcore_mo)
+    norm_sc_T = sum(np.sum(np.abs(hk.real)+np.abs(hk.imag)) for hk in supercell_hcore_mo)
+    supcell = supercell_mf.cell
+    assert np.isclose(norm_uc_T, norm_sc_T)
+
+    # Sanity check: Build Nk^3 eris directly and sum up outside of loop
+    eris_uc = np.zeros((nkpts,)*3 + (nmo,)*4, dtype=np.complex128)
+    kconserv = get_kconserv(cell, kpts)
+    for k1, k2, k3 in loop_kkk(nkpts):
+        k4 = kconserv[k1, k2, k3]
+        kpts = [k1, k2, k3, k4]
+        eris_uc[k1, k2, k3] = helper.get_eri(kpts)
+
+    eris_uc = eris_uc / nkpts
+    norm_uc = np.linalg.norm(eris_uc.ravel())
+    eris_sc = supercell_helper.get_eri([0,0,0,0])
+    norm_sc = np.linalg.norm(eris_sc.ravel())
+    # Test 2-norm should be invariant wrt unitary.
+    assert np.isclose(norm_uc, norm_sc)
+    # Test the triple loop
+    direct_uc = np.sum(np.abs(eris_uc.real)+np.abs(eris_uc.imag))
+    assert np.isclose(direct_uc, lambda_two_body)
+
     assert np.isclose(sc_lambda_one_body, lambda_one_body)
     assert np.isclose(sc_lambda_two_body, lambda_two_body)
+
 
 def test_symmetric_ortho_localization():
     cell = gto.Cell()

--- a/kpoint_eri/resource_estimates/utils/k2gamma_test.py
+++ b/kpoint_eri/resource_estimates/utils/k2gamma_test.py
@@ -1,0 +1,52 @@
+import numpy as np
+from functools import reduce
+
+from pyscf.pbc import gto, scf, mp, cc, tools
+from pyscf.pbc.tools.k2gamma import k2gamma as pyscf_k2gamma
+from kpoint_eri.resource_estimates.utils.k2gamma import k2gamma, get_phase
+from pyscf.pbc.lib.kpts_helper import conj_mapping
+
+def test_make_real():
+    cell = gto.Cell()
+    cell.atom = '''
+    C 0.000000000000   0.000000000000   0.000000000000
+    C 1.685068664391   1.685068664391   1.685068664391
+    '''
+    cell.basis = 'gth-szv'
+    cell.pseudo = 'gth-hf-rev'
+    cell.a = '''
+    0.000000000, 3.370137329, 3.370137329
+    3.370137329, 0.000000000, 3.370137329
+    3.370137329, 3.370137329, 0.000000000'''
+    cell.unit = 'B'
+    cell.verbose = 3
+    cell.build()
+
+    kmesh = [1, 1, 3]
+    kpts = cell.make_kpts(kmesh)
+    mf = scf.KRHF(cell, kpts).rs_density_fit()
+    nkpts = np.prod(kmesh)
+    mf.chkfile = f'test_make_real_{nkpts}.chk'
+    mf.with_df._cderi_to_save = mf.chkfile
+    mf.init_guess = 'chkfile'
+    mf.kernel()
+    kminus = conj_mapping(cell, kpts)
+
+    hcore_ao = mf.get_hcore()
+    hcore_mo = np.asarray([reduce(np.dot, (mo.T.conj(), hcore_ao[k], mo)) for k, mo in enumerate(mf.mo_coeff)])
+
+    supercell_mf = k2gamma(mf, make_real=False)
+    supercell_hcore_ao = supercell_mf.get_hcore()
+    supercell_hcore_mo = np.asarray([reduce(np.dot, (mo.T.conj(), supercell_hcore_ao[k], mo)) for k, mo in enumerate(supercell_mf.mo_coeff)])
+    norm_uc_T = sum(np.sum(np.abs(hk.real)+np.abs(hk.imag)) for hk in hcore_mo)
+    norm_sc_T = sum(np.sum(np.abs(hk.real)+np.abs(hk.imag)) for hk in supercell_hcore_mo)
+    assert np.isclose(norm_uc_T, norm_sc_T)
+    supercell_mf = k2gamma(mf, make_real=True)
+    supercell_hcore_ao = supercell_mf.get_hcore()
+    supercell_hcore_mo = np.asarray([reduce(np.dot, (mo.T.conj(), supercell_hcore_ao[k], mo)) for k, mo in enumerate(supercell_mf.mo_coeff)])
+    norm_uc_T = sum(np.sum(np.abs(hk.real)+np.abs(hk.imag)) for hk in hcore_mo)
+    norm_sc_T = sum(np.sum(np.abs(hk.real)+np.abs(hk.imag)) for hk in supercell_hcore_mo)
+    assert not np.isclose(norm_uc_T, norm_sc_T)
+
+if __name__ == "__main__":
+    test_make_real()


### PR DESCRIPTION
Forcing MOs to be totally real leads to disagreement between lambdas computed in unit cell and supercell. Relaxing reality constraint leads to numerical agreemenet.