### PR TITLE
lambda THC corrected and exact ERI

### DIFF
--- a/kpoint_eri/resource_estimates/thc/integral_helper_test.py
+++ b/kpoint_eri/resource_estimates/thc/integral_helper_test.py
@@ -86,3 +86,6 @@ def test_thc_helper():
     emp2, _, _ = approx_cc.init_amps(eris)
     delta = abs(emp2 - exact_emp2)
     print(" {:4d}  {:10.4e} {:10.4e} {:10.4e}".format(num_interp_points, delta, emp2, exact_emp2))
+
+if __name__ == "__main__":
+    test_thc_helper()


### PR DESCRIPTION
lambda THC now correctly separates real and imaginary components

exact ERI uses the mean-field object to produce the exact ERI and not Cholesky. This is needed for the exchange term that is subtracted from the 1-body operator.