### PR TITLE
Fix lambda thc

### DIFF
--- a/kpoint_eri/resource_estimates/thc/compute_lambda_thc.py
+++ b/kpoint_eri/resource_estimates/thc/compute_lambda_thc.py
@@ -103,7 +103,10 @@ def compute_lambda_ncr_v2(hcore, thc_obj: KPTHCHelperDoubleTranslation):
         MPQ_normalized = np.einsum("P,xyPQ,Q->xyPQ", cP, zeta_Q, cP)
         lambda_two_body += np.sum(np.abs(MPQ_normalized.real))
         lambda_two_body += np.sum(np.abs(MPQ_normalized.imag))
-    lambda_two_body *= 2 * nkpts**2
+    # Nk^2 to account for k, k_prime sum, but we drop factor of Nk due to how
+    # eris are defined to be consistent with pyscf (i.e. there is a 1/Nk
+    # normalization factor of the eris in pyscf.)
+    lambda_two_body *= 2 * nkpts
 
     lambda_tot = lambda_one_body + lambda_two_body
     return lambda_tot, lambda_one_body, lambda_two_body

--- a/kpoint_eri/resource_estimates/thc/compute_lambda_thc.py
+++ b/kpoint_eri/resource_estimates/thc/compute_lambda_thc.py
@@ -103,9 +103,9 @@ def compute_lambda_ncr_v2(hcore, thc_obj: KPTHCHelperDoubleTranslation):
         MPQ_normalized = np.einsum("P,xyPQ,Q->xyPQ", cP, zeta_Q, cP)
         lambda_two_body += np.sum(np.abs(MPQ_normalized.real))
         lambda_two_body += np.sum(np.abs(MPQ_normalized.imag))
-    # Nk^2 to account for k, k_prime sum, but we drop factor of Nk due to how
-    # eris are defined to be consistent with pyscf (i.e. there is a 1/Nk
-    # normalization factor of the eris in pyscf.)
+    # Nk^2 to account for k, k_prime sum. This multiplies a 1/Nk factor present
+    # in the definition of the eris in pyscf which the THC factors are
+    # constructed to reproduce.
     lambda_two_body *= 2 * nkpts
 
     lambda_tot = lambda_one_body + lambda_two_body


### PR DESCRIPTION
Accounts for factor of 1/Nk normalization factor which reduces prefactor from Nk^2 to Nk .